### PR TITLE
Update minecraft protocol

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.gomint</groupId>
     <artifactId>jraknet</artifactId>
-    <version>7.0.10-SNAPSHOT</version>
+    <version>7.0.11-SNAPSHOT</version>
 
     <repositories>
         <repository>

--- a/src/main/java/io/gomint/jraknet/RakNetConstraints.java
+++ b/src/main/java/io/gomint/jraknet/RakNetConstraints.java
@@ -9,7 +9,7 @@ public class RakNetConstraints {
     // =========================== CONSTANTS =========================== //
 
     // Version of the RakNet library's protocol MCPE is using
-    public static final byte RAKNET_PROTOCOL_VERSION_MOJANG = 10;
+    public static final byte RAKNET_PROTOCOL_VERSION_MOJANG = 11;
 
     // Version of the original RakNet lib without modifications
     public static final byte RAKNET_PROTOCOL_VERSION = 6;


### PR DESCRIPTION
Update the Minecraft Bedrock protocol modification version to the latest (1.19+)